### PR TITLE
Added support for searching by administration area or country

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ systemctl start geocoding-api.service
 systemctl status geocoding-api.service
 ```
 
-Additionally, nginx proxy should be used
+Geonames data are parsed and processed during the first start, which requires some times and memor. At least 6GB RAM is required and it takes about 25 minutes on a CPU with 2 Skylake cores. Database loading takes about 5 minutes after that.
+
+Additionally, nginx proxy should be used.
 
 ## Terms & Privacy
 Open-Meteo APIs are free for open-source developer and non-commercial use. We do not restrict access, but ask for fair use.

--- a/Sources/App/GeocodingapiController.swift
+++ b/Sources/App/GeocodingapiController.swift
@@ -63,7 +63,10 @@ struct GeocodingapiController: RouteCollection {
             name = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
             let areaName = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
             if areaName.count > 1 {
-                areaIds = database.search(areaName, languageId: Int32(languageId), maxCount: 10).map({
+                areaIds = database.search(areaName, languageId: Int32(languageId), maxCount: 10).compactMap({
+                    guard ["ADM1","ADM2","ADM3","ADM4","PCLI"].contains(database.geonames.geonames[$0.0]?.featureCode) else {
+                        return nil
+                    }
                     return $0.0
                 })
             }

--- a/Sources/App/GeocodingapiController.swift
+++ b/Sources/App/GeocodingapiController.swift
@@ -55,8 +55,21 @@ struct GeocodingapiController: RouteCollection {
         let language = params.language ?? "en"
         let languageId = database.geonames.languages.firstIndex(of: language) ?? database.geonames.languages.firstIndex(of: "en")!
         let count = try params.getCount()
-        
-        var results = params.name.count < 2 ? [] : database.search(params.name, languageId: Int32(languageId), maxCount: count)
+
+        var name = params.name
+        var areaIds: [Int32]?
+        if name.contains(",") { // Split string by comma, so we can filter the results later by second part
+            let parts = name.components(separatedBy: ",")
+            name = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let areaName = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            if areaName.count > 1 {
+                areaIds = database.search(areaName, languageId: Int32(languageId), maxCount: 10).map({
+                    return $0.0
+                })
+            }
+        }
+
+        var results = params.name.count < 2 ? [] : database.search(name, languageId: Int32(languageId), maxCount: count)
         /// TODO country filter need to be inside database match, because `count` would be wrong otherwise
         if let countryCode = params.countryCode {
             /*guard let countryId = searchTree.geonames.countryIso2.firstIndex(of: countryCode) else {
@@ -67,6 +80,15 @@ struct GeocodingapiController: RouteCollection {
                     return false
                 }
                 return c == countryCode
+            })
+        }
+        if let areas = areaIds {
+            results = results.filter({ // Filter the results by second part of the original string
+                return areas.contains(database.geonames.geonames[$0.0]?.admin1ID ?? -1)
+                    || areas.contains(database.geonames.geonames[$0.0]?.admin2ID ?? -1)
+                    || areas.contains(database.geonames.geonames[$0.0]?.admin3ID ?? -1)
+                    || areas.contains(database.geonames.geonames[$0.0]?.admin4ID ?? -1)
+                    || areas.contains(database.geonames.geonames[$0.0]?.countryID ?? -1)
             })
         }
         let mapped: [GeocodingApi.Geoname] = results.map({


### PR DESCRIPTION
The input string "name" is split by comma character (","), first part is used for the original search, seconds part is used for separate search for administration areas and countries. 

This can be used for example to search for city Queenstown in New Zealand with query "/v1/search?name=Queenstown,New Zealand".

If the input string doesn't contain comma, it works as previously.

Partially solves https://github.com/open-meteo/open-meteo/issues/125.