### PR TITLE
feat: Correctly support filtering by admin 1

### DIFF
--- a/Sources/App/AdministrativeAreaLookup.swift
+++ b/Sources/App/AdministrativeAreaLookup.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// Resolves exact names and abbreviations for first-level administrative areas and countries.
+struct AdministrativeAreaLookup {
+    struct Resolution {
+        var admin1IDs: Set<Int32>
+        var countryCodes: Set<String>
+
+        init(admin1IDs: Set<Int32> = [], countryCodes: Set<String> = []) {
+            self.admin1IDs = admin1IDs
+            self.countryCodes = countryCodes
+        }
+
+        var isEmpty: Bool {
+            return admin1IDs.isEmpty && countryCodes.isEmpty
+        }
+    }
+
+    private struct LocalizedAlias: Hashable {
+        let languageID: Int32
+        let alias: String
+    }
+
+    private struct AliasCandidate: Hashable {
+        let admin1ID: Int32?
+        let countryCode: String
+    }
+
+    private enum AliasMatches {
+        case single(AliasCandidate)
+        case multiple(Set<AliasCandidate>)
+
+        mutating func insert(_ candidate: AliasCandidate) {
+            switch self {
+            case .single(let existing):
+                guard existing != candidate else {
+                    return
+                }
+                self = .multiple([existing, candidate])
+            case .multiple(var candidates):
+                candidates.insert(candidate)
+                self = .multiple(candidates)
+            }
+        }
+
+        func formResolution(into resolution: inout Resolution, countryCode: String?) {
+            func add(_ candidate: AliasCandidate) {
+                guard countryCode == nil || candidate.countryCode == countryCode else {
+                    return
+                }
+                if let admin1ID = candidate.admin1ID {
+                    resolution.admin1IDs.insert(admin1ID)
+                } else if !candidate.countryCode.isEmpty {
+                    resolution.countryCodes.insert(candidate.countryCode)
+                }
+            }
+
+            switch self {
+            case .single(let candidate):
+                add(candidate)
+            case .multiple(let candidates):
+                for candidate in candidates {
+                    add(candidate)
+                }
+            }
+        }
+
+        func resolution(countryCode: String?) -> Resolution {
+            var resolution = Resolution()
+            formResolution(into: &resolution, countryCode: countryCode)
+            return resolution
+        }
+    }
+
+    private let idsByCommonAlias: [String: AliasMatches]
+    private let idsByLocalizedAlias: [LocalizedAlias: AliasMatches]
+    private let adm1IDsByAbbreviation: [String: AliasMatches]
+
+    init(geonames: GeocodingDatabase.Geonames) {
+        let abbreviationLanguageID = geonames.languages.firstIndex(of: "abbr").map(Int32.init)
+        let englishLanguageID = geonames.languages.firstIndex(of: "en").map(Int32.init)
+        var idsByCommonAlias = [String: AliasMatches]()
+        var idsByLocalizedAlias = [LocalizedAlias: AliasMatches]()
+        var adm1IDsByAbbreviation = [String: AliasMatches]()
+
+        func add(_ alias: String, candidate: AliasCandidate, to index: inout [String: AliasMatches]) {
+            let normalized = Self.normalize(alias)
+            guard !normalized.isEmpty else {
+                return
+            }
+            Self.insert(candidate, for: normalized, into: &index)
+        }
+
+        for (id, geoname) in geonames.geonames
+        where geoname.featureCode == "ADM1" || Self.isCountry(featureCode: geoname.featureCode) {
+            let isCountry = Self.isCountry(featureCode: geoname.featureCode)
+            let candidate = AliasCandidate(
+                admin1ID: isCountry ? nil : id,
+                countryCode: Self.normalizeCountryCode(geoname.countryIso2)
+            )
+            add(geoname.name, candidate: candidate, to: &idsByCommonAlias)
+
+            for (languageID, alternativeName) in geoname.alternativeNames {
+                if languageID == abbreviationLanguageID {
+                    if !isCountry {
+                        add(alternativeName, candidate: candidate, to: &adm1IDsByAbbreviation)
+                    } else {
+                        add(alternativeName, candidate: candidate, to: &idsByCommonAlias)
+                    }
+                } else if languageID == englishLanguageID {
+                    add(alternativeName, candidate: candidate, to: &idsByCommonAlias)
+                } else {
+                    let normalized = Self.normalize(alternativeName)
+                    guard !normalized.isEmpty else {
+                        continue
+                    }
+                    let key = LocalizedAlias(languageID: languageID, alias: normalized)
+                    Self.insert(candidate, for: key, into: &idsByLocalizedAlias)
+                }
+            }
+
+            if isCountry {
+                add(geoname.countryIso2, candidate: candidate, to: &idsByCommonAlias)
+            }
+        }
+
+        self.idsByCommonAlias = idsByCommonAlias
+        self.idsByLocalizedAlias = idsByLocalizedAlias
+        self.adm1IDsByAbbreviation = adm1IDsByAbbreviation
+    }
+
+    func resolve(_ value: String, languageID: Int32, countryCode: String? = nil) -> Resolution {
+        let normalized = Self.normalize(value)
+        let normalizedCountryCode = countryCode.map(Self.normalizeCountryCode)
+
+        // In a comma qualifier, an ADM1 abbreviation is more specific than a colliding country code.
+        if let adm1Matches = adm1IDsByAbbreviation[normalized] {
+            let resolution = adm1Matches.resolution(countryCode: normalizedCountryCode)
+            if !resolution.isEmpty {
+                return resolution
+            }
+        }
+
+        var resolution = Resolution()
+        idsByCommonAlias[normalized]?.formResolution(
+            into: &resolution,
+            countryCode: normalizedCountryCode
+        )
+        let localizedAlias = LocalizedAlias(languageID: languageID, alias: normalized)
+        idsByLocalizedAlias[localizedAlias]?.formResolution(
+            into: &resolution,
+            countryCode: normalizedCountryCode
+        )
+        return resolution
+    }
+
+    private static func insert<Key: Hashable>(
+        _ candidate: AliasCandidate,
+        for key: Key,
+        into index: inout [Key: AliasMatches]
+    ) {
+        if var matches = index[key] {
+            matches.insert(candidate)
+            index[key] = matches
+        } else {
+            index[key] = .single(candidate)
+        }
+    }
+
+    private static func normalize(_ value: String) -> String {
+        return
+            value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: .diacriticInsensitive, locale: nil)
+            .lowercased()
+    }
+
+    private static func normalizeCountryCode(_ value: String) -> String {
+        return value.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+
+    private static func isCountry(featureCode: String) -> Bool {
+        switch featureCode {
+        case "PCLI", "PCLD", "PCLIX", "PCLS", "PCLF", "PCL":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/App/AdministrativeAreaLookup.swift
+++ b/Sources/App/AdministrativeAreaLookup.swift
@@ -78,6 +78,7 @@ struct AdministrativeAreaLookup {
 
     init(geonames: GeocodingDatabase.Geonames) {
         let abbreviationLanguageID = geonames.languages.firstIndex(of: "abbr").map(Int32.init)
+        let languageNeutralID = geonames.languages.firstIndex(of: "").map(Int32.init)
         let englishLanguageID = geonames.languages.firstIndex(of: "en").map(Int32.init)
         var idsByCommonAlias = [String: AliasMatches]()
         var idsByLocalizedAlias = [LocalizedAlias: AliasMatches]()
@@ -107,7 +108,7 @@ struct AdministrativeAreaLookup {
                     } else {
                         add(alternativeName, candidate: candidate, to: &idsByCommonAlias)
                     }
-                } else if languageID == englishLanguageID {
+                } else if languageID == languageNeutralID || languageID == englishLanguageID {
                     add(alternativeName, candidate: candidate, to: &idsByCommonAlias)
                 } else {
                     let normalized = Self.normalize(alternativeName)

--- a/Sources/App/GeocodingDatabase.swift
+++ b/Sources/App/GeocodingDatabase.swift
@@ -40,9 +40,40 @@ extension GeocodingDatabase {
     }
 
     /// Search for a string in the indexed location names and one language index
-    public func search(_ searchString: String, languageId: Int32, maxCount: Int) -> [(Int32, Float)] {
+    func search(
+        _ searchString: String,
+        languageId: Int32,
+        maxCount: Int,
+        countryCode: String? = nil,
+        administrativeArea: AdministrativeAreaLookup.Resolution? = nil
+    ) -> [(Int32, Float)] {
         let stripped = searchString.folding(options: .diacriticInsensitive, locale: nil).lowercased()
-        let results = PriorityQueue(length: maxCount)
+        let normalizedCountryCode =
+            countryCode?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+        let results: PriorityQueue
+        if normalizedCountryCode == nil && administrativeArea == nil {
+            results = PriorityQueue(length: maxCount)
+        } else {
+            let geonamesByID = geonames.geonames
+            results = PriorityQueue(
+                length: maxCount,
+                accepts: { id in
+                    guard let geoname = geonamesByID[id] else {
+                        return false
+                    }
+                    if let normalizedCountryCode, geoname.countryIso2 != normalizedCountryCode {
+                        return false
+                    }
+                    if let administrativeArea {
+                        return administrativeArea.admin1IDs.contains(geoname.admin1ID)
+                            || administrativeArea.countryCodes.contains(geoname.countryIso2)
+                    }
+                    return true
+                }
+            )
+        }
         let onlyExact = searchString.count <= 2
         index.search(Substring(stripped), results: results, onlyExact: onlyExact, geonames: geonames.geonames)
         languageIndex[Int(languageId)].search(

--- a/Sources/App/GeocodingapiController.swift
+++ b/Sources/App/GeocodingapiController.swift
@@ -27,6 +27,20 @@ struct GeocodingapiController: RouteCollection {
         self.administrativeAreas = AdministrativeAreaLookup(geonames: database.geonames)
     }
 
+    static func parseSearchName(_ value: String) -> (name: String, areaName: String?) {
+        guard let comma = value.firstIndex(of: ",") else {
+            return (value.trimmingCharacters(in: .whitespacesAndNewlines), nil)
+        }
+
+        let name = String(value[..<comma]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let areaStart = value.index(after: comma)
+        let areaEnd = value[areaStart...].firstIndex(of: ",") ?? value.endIndex
+        let areaName =
+            String(value[areaStart..<areaEnd])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (name, areaName.isEmpty ? nil : areaName)
+    }
+
     func boot(routes: RoutesBuilder) throws {
         let cors = CORSMiddleware(
             configuration: .init(
@@ -65,31 +79,20 @@ struct GeocodingapiController: RouteCollection {
             database.geonames.languages.firstIndex(of: language) ?? database.geonames.languages.firstIndex(of: "en")!
         let count = try params.getCount()
 
-        let name: String
-        var administrativeAreaResolution: AdministrativeAreaLookup.Resolution?
-        if let comma = params.name.firstIndex(of: ",") {
-            name = String(params.name[..<comma]).trimmingCharacters(in: .whitespacesAndNewlines)
-            let areaStart = params.name.index(after: comma)
-            let areaEnd = params.name[areaStart...].firstIndex(of: ",") ?? params.name.endIndex
-            let areaName =
-                String(params.name[areaStart..<areaEnd])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            if !areaName.isEmpty {
-                administrativeAreaResolution = administrativeAreas.resolve(
-                    areaName,
-                    languageID: Int32(languageId),
-                    countryCode: params.countryCode
-                )
-            }
-        } else {
-            name = params.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parsedName = Self.parseSearchName(params.name)
+        let administrativeAreaResolution = parsedName.areaName.map {
+            administrativeAreas.resolve(
+                $0,
+                languageID: Int32(languageId),
+                countryCode: params.countryCode
+            )
         }
 
         let results =
-            name.count < 2
+            parsedName.name.count < 2
             ? []
             : database.search(
-                name,
+                parsedName.name,
                 languageId: Int32(languageId),
                 maxCount: count,
                 countryCode: params.countryCode,

--- a/Sources/App/GeocodingapiController.swift
+++ b/Sources/App/GeocodingapiController.swift
@@ -16,9 +16,15 @@ import Vapor
 
 struct GeocodingapiController: RouteCollection {
     let database: GeocodingDatabase
+    let administrativeAreas: AdministrativeAreaLookup
 
     public init(_ app: Application) throws {
-        database = try GeocodingDatabase.loadOrCreate(logger: app.logger)
+        self.init(database: try GeocodingDatabase.loadOrCreate(logger: app.logger))
+    }
+
+    init(database: GeocodingDatabase) {
+        self.database = database
+        self.administrativeAreas = AdministrativeAreaLookup(geonames: database.geonames)
     }
 
     func boot(routes: RoutesBuilder) throws {
@@ -59,46 +65,34 @@ struct GeocodingapiController: RouteCollection {
             database.geonames.languages.firstIndex(of: language) ?? database.geonames.languages.firstIndex(of: "en")!
         let count = try params.getCount()
 
-        var name = params.name
-        var areaIds: [Int32]?
-        if name.contains(",") {  // Split string by comma, so we can filter the results later by second part
-            let parts = name.components(separatedBy: ",")
-            name = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-            let areaName = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            if areaName.count > 1 {
-                areaIds = database.search(areaName, languageId: Int32(languageId), maxCount: 10).compactMap({
-                    guard
-                        ["ADM1", "ADM2", "ADM3", "ADM4", "PCLI"].contains(database.geonames.geonames[$0.0]?.featureCode)
-                    else {
-                        return nil
-                    }
-                    return $0.0
-                })
+        let name: String
+        var administrativeAreaResolution: AdministrativeAreaLookup.Resolution?
+        if let comma = params.name.firstIndex(of: ",") {
+            name = String(params.name[..<comma]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let areaName =
+                String(params.name[params.name.index(after: comma)...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !areaName.isEmpty {
+                administrativeAreaResolution = administrativeAreas.resolve(
+                    areaName,
+                    languageID: Int32(languageId),
+                    countryCode: params.countryCode
+                )
             }
+        } else {
+            name = params.name.trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
-        var results = params.name.count < 2 ? [] : database.search(name, languageId: Int32(languageId), maxCount: count)
-        /// TODO country filter need to be inside database match, because `count` would be wrong otherwise
-        if let countryCode = params.countryCode {
-            /*guard let countryId = searchTree.geonames.countryIso2.firstIndex(of: countryCode) else {
-                throw GeocodingApiError.invalidContryCode
-            }*/
-            results = results.filter({
-                guard let c = database.geonames.geonames[$0.0]?.countryIso2 else {
-                    return false
-                }
-                return c == countryCode
-            })
-        }
-        if let areas = areaIds {
-            results = results.filter({  // Filter the results by second part of the original string
-                return areas.contains(database.geonames.geonames[$0.0]?.admin1ID ?? -1)
-                    || areas.contains(database.geonames.geonames[$0.0]?.admin2ID ?? -1)
-                    || areas.contains(database.geonames.geonames[$0.0]?.admin3ID ?? -1)
-                    || areas.contains(database.geonames.geonames[$0.0]?.admin4ID ?? -1)
-                    || areas.contains(database.geonames.geonames[$0.0]?.countryID ?? -1)
-            })
-        }
+        let results =
+            name.count < 2
+            ? []
+            : database.search(
+                name,
+                languageId: Int32(languageId),
+                maxCount: count,
+                countryCode: params.countryCode,
+                administrativeArea: administrativeAreaResolution
+            )
         let mapped: [GeocodingApi.Geoname] = results.map({
             guard let geoname = database.geonames.getResponse(id: $0.0, languageId: Int32(languageId), searchRank: $0.1)
             else {

--- a/Sources/App/GeocodingapiController.swift
+++ b/Sources/App/GeocodingapiController.swift
@@ -69,8 +69,10 @@ struct GeocodingapiController: RouteCollection {
         var administrativeAreaResolution: AdministrativeAreaLookup.Resolution?
         if let comma = params.name.firstIndex(of: ",") {
             name = String(params.name[..<comma]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let areaStart = params.name.index(after: comma)
+            let areaEnd = params.name[areaStart...].firstIndex(of: ",") ?? params.name.endIndex
             let areaName =
-                String(params.name[params.name.index(after: comma)...])
+                String(params.name[areaStart..<areaEnd])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if !areaName.isEmpty {
                 administrativeAreaResolution = administrativeAreas.resolve(

--- a/Sources/App/Structures.swift
+++ b/Sources/App/Structures.swift
@@ -111,12 +111,17 @@ final class SearchTreeLoader {
 /// Order search results by priority
 public final class PriorityQueue {
     public var queue: [(id: Int32, priority: Float)]
+    private let accepts: ((Int32) -> Bool)?
 
-    public init(length: Int) {
+    public init(length: Int, accepts: ((Int32) -> Bool)? = nil) {
         queue = [(Int32, Float)](repeating: (0, 0), count: length)
+        self.accepts = accepts
     }
 
     public func insert(id: Int32, priority: Float) {
+        guard accepts?(id) ?? true else {
+            return
+        }
         // if duplicate id, remove it and then insert like regular
         if let duplicate = queue.firstIndex(where: { $0.id == id }) {
             if queue[duplicate].priority >= priority {

--- a/Tests/AppTests/AdministrativeAreaLookupTests.swift
+++ b/Tests/AppTests/AdministrativeAreaLookupTests.swift
@@ -1,0 +1,401 @@
+import XCTest
+
+@testable import App
+
+final class AdministrativeAreaLookupTests: XCTestCase {
+    private enum ID {
+        static let india: Int32 = 1
+        static let unitedStates: Int32 = 2
+        static let indiana: Int32 = 3
+        static let delhiIndia: Int32 = 4
+        static let delhiAdministrativeArea: Int32 = 5
+        static let delhiIndiana: Int32 = 6
+        static let sharedIndia: Int32 = 7
+        static let sharedUnitedStates: Int32 = 8
+        static let puertoRico: Int32 = 9
+        static let sanJuanMunicipality: Int32 = 10
+        static let sanJuan: Int32 = 11
+        static let guam: Int32 = 12
+        static let dededoMunicipality: Int32 = 13
+        static let dededoVillage: Int32 = 14
+        static let hongKong: Int32 = 15
+    }
+
+    private enum LanguageID {
+        static let english: Int32 = 1
+        static let abbreviation: Int32 = 2
+        static let german: Int32 = 5
+    }
+
+    func testExplicitCountryDisambiguatesCountryCodeFromADM1Abbreviation() {
+        let lookup = AdministrativeAreaLookup(geonames: makeGeonames())
+
+        let withoutCountry = lookup.resolve("IN", languageID: LanguageID.english)
+        XCTAssertEqual(withoutCountry.admin1IDs, [ID.indiana])
+        XCTAssertEqual(withoutCountry.countryCodes, [])
+
+        let india = lookup.resolve("IN", languageID: LanguageID.english, countryCode: "IN")
+        XCTAssertEqual(india.admin1IDs, [])
+        XCTAssertEqual(india.countryCodes, ["IN"])
+
+        let unitedStates = lookup.resolve("IN", languageID: LanguageID.english, countryCode: " us ")
+        XCTAssertEqual(unitedStates.admin1IDs, [ID.indiana])
+        XCTAssertEqual(unitedStates.countryCodes, [])
+
+        let normalizedIndia = lookup.resolve("IN", languageID: LanguageID.english, countryCode: " in ")
+        XCTAssertEqual(normalizedIndia.admin1IDs, [])
+        XCTAssertEqual(normalizedIndia.countryCodes, ["IN"])
+
+        XCTAssertTrue(
+            lookup.resolve("IN", languageID: LanguageID.english, countryCode: "ZZ").isEmpty
+        )
+        XCTAssertTrue(
+            lookup.resolve("IN", languageID: LanguageID.english, countryCode: "  ").isEmpty
+        )
+    }
+
+    func testAliasCollisionsRemainDeduplicatedAndRespectCountryContext() {
+        let lookup = AdministrativeAreaLookup(geonames: makeGeonames())
+
+        XCTAssertEqual(
+            lookup.resolve("Shared Region", languageID: LanguageID.english).admin1IDs,
+            [ID.sharedIndia, ID.sharedUnitedStates]
+        )
+        XCTAssertEqual(
+            lookup.resolve("Shared Region", languageID: LanguageID.english, countryCode: "IN").admin1IDs,
+            [ID.sharedIndia]
+        )
+        XCTAssertEqual(
+            lookup.resolve("Gemeinsam", languageID: LanguageID.german).admin1IDs,
+            [ID.sharedIndia, ID.sharedUnitedStates]
+        )
+    }
+
+    func testLanguageNeutralAliasesAreAvailableInEveryRequestedLanguage() {
+        let lookup = AdministrativeAreaLookup(geonames: makeGeonames())
+
+        let resolution = lookup.resolve("Republic of India", languageID: LanguageID.english)
+        XCTAssertEqual(resolution.admin1IDs, [])
+        XCTAssertEqual(resolution.countryCodes, ["IN"])
+    }
+
+    func testAllCountryFeatureCodesAreIndexed() {
+        let featureCodes = ["PCLI", "PCLD", "PCLIX", "PCLS", "PCLF", "PCL"]
+        let countryCodes = ["AA", "AB", "AC", "AD", "AE", "AF"]
+        var geonames = GeocodingDatabase.Geonames()
+        geonames.languages = ["en"]
+
+        for (offset, featureCode) in featureCodes.enumerated() {
+            let id = Int32(offset + 1)
+            geonames.geonames[id] = makeGeoname(
+                id: id,
+                name: "\(featureCode) Territory",
+                featureCode: featureCode,
+                countryCode: countryCodes[offset],
+                countryID: 0
+            )
+        }
+
+        let lookup = AdministrativeAreaLookup(geonames: geonames)
+        for (offset, featureCode) in featureCodes.enumerated() {
+            let resolution = lookup.resolve(
+                "\(featureCode) Territory",
+                languageID: 0
+            )
+            XCTAssertEqual(resolution.admin1IDs, [])
+            XCTAssertEqual(resolution.countryCodes, [countryCodes[offset]])
+
+            let isoResolution = lookup.resolve(
+                countryCodes[offset],
+                languageID: 0,
+                countryCode: countryCodes[offset].lowercased()
+            )
+            XCTAssertEqual(isoResolution.admin1IDs, [])
+            XCTAssertEqual(isoResolution.countryCodes, [countryCodes[offset]])
+        }
+
+        geonames.geonames[100] = makeGeoname(
+            id: 100,
+            name: "No ISO Territory",
+            featureCode: "PCLD",
+            countryCode: "",
+            countryID: 0
+        )
+        XCTAssertTrue(
+            AdministrativeAreaLookup(geonames: geonames)
+                .resolve("No ISO Territory", languageID: 0)
+                .isEmpty
+        )
+    }
+
+    func testDependentTerritoriesResolveWithoutCountryIDs() {
+        let lookup = AdministrativeAreaLookup(geonames: makeGeonames())
+
+        let puertoRico = lookup.resolve("Puerto Rico", languageID: LanguageID.english)
+        XCTAssertEqual(puertoRico.admin1IDs, [])
+        XCTAssertEqual(puertoRico.countryCodes, ["PR"])
+
+        let guam = lookup.resolve(
+            "Dededo Municipality",
+            languageID: LanguageID.english,
+            countryCode: "GU"
+        )
+        XCTAssertEqual(guam.admin1IDs, [ID.dededoMunicipality])
+        XCTAssertEqual(guam.countryCodes, [])
+
+        let hongKong = lookup.resolve(
+            "Hong Kong",
+            languageID: LanguageID.english,
+            countryCode: "HK"
+        )
+        XCTAssertEqual(hongKong.admin1IDs, [])
+        XCTAssertEqual(hongKong.countryCodes, ["HK"])
+    }
+
+    func testDatabaseSearchWithAndWithoutFilters() {
+        let database = makeDatabase()
+        let lookup = AdministrativeAreaLookup(geonames: database.geonames)
+
+        XCTAssertEqual(
+            database.search("Delhi", languageId: LanguageID.english, maxCount: 10).map(\.0),
+            [ID.delhiIndia, ID.delhiIndiana]
+        )
+        XCTAssertEqual(
+            database.search(
+                "Delhi",
+                languageId: LanguageID.english,
+                maxCount: 10,
+                countryCode: " in "
+            ).map(\.0),
+            [ID.delhiIndia]
+        )
+        XCTAssertEqual(
+            database.search(
+                "Delhi",
+                languageId: LanguageID.english,
+                maxCount: 10,
+                administrativeArea: lookup.resolve(
+                    "Indiana",
+                    languageID: LanguageID.english
+                )
+            ).map(\.0),
+            [ID.delhiIndiana]
+        )
+        XCTAssertEqual(
+            database.search(
+                "Delhi",
+                languageId: LanguageID.english,
+                maxCount: 10,
+                countryCode: "IN",
+                administrativeArea: lookup.resolve(
+                    "IN",
+                    languageID: LanguageID.english,
+                    countryCode: "IN"
+                )
+            ).map(\.0),
+            [ID.delhiIndia]
+        )
+        XCTAssertEqual(
+            database.search(
+                "San Juan",
+                languageId: LanguageID.english,
+                maxCount: 10,
+                administrativeArea: lookup.resolve(
+                    "Puerto Rico",
+                    languageID: LanguageID.english
+                )
+            ).map(\.0),
+            [ID.sanJuan]
+        )
+    }
+
+    func testQualifierStopsAtNextComma() {
+        let parsed = GeocodingapiController.parseSearchName(
+            " Delhi, National Capital Territory of Delhi, IN "
+        )
+
+        XCTAssertEqual(parsed.name, "Delhi")
+        XCTAssertEqual(parsed.areaName, "National Capital Territory of Delhi")
+    }
+
+    private func makeDatabase() -> GeocodingDatabase {
+        let geonames = makeGeonames()
+        let mainIndex = SearchTreeLoader()
+        let languageIndexes = geonames.languages.map { _ in SearchTreeLoader() }
+
+        for (id, geoname) in geonames.geonames
+        where geonames.includeInSearchIndex(featureCode: geoname.featureCode) {
+            mainIndex.add(geoname.name, id: id)
+            for (languageID, alternativeName) in geoname.alternativeNames {
+                languageIndexes[Int(languageID)].add(alternativeName, id: id)
+            }
+        }
+
+        var database = GeocodingDatabase()
+        database.geonames = geonames
+        database.index = mainIndex.immutable()
+        database.languageIndex = languageIndexes.map { $0.immutable() }
+        return database
+    }
+
+    private func makeGeonames() -> GeocodingDatabase.Geonames {
+        var geonames = GeocodingDatabase.Geonames()
+        geonames.languages = ["", "en", "abbr", "icao", "iata", "de"]
+        geonames.timezones = ["UTC"]
+        geonames.geonames = [
+            ID.india: makeGeoname(
+                id: ID.india,
+                name: "India",
+                featureCode: "PCLI",
+                countryCode: "IN",
+                countryID: ID.india,
+                alternativeNames: [0: "Republic of India"]
+            ),
+            ID.unitedStates: makeGeoname(
+                id: ID.unitedStates,
+                name: "United States",
+                featureCode: "PCLI",
+                countryCode: "US",
+                countryID: ID.unitedStates
+            ),
+            ID.indiana: makeGeoname(
+                id: ID.indiana,
+                name: "Indiana",
+                featureCode: "ADM1",
+                countryCode: "US",
+                countryID: ID.unitedStates,
+                admin1ID: ID.indiana,
+                alternativeNames: [LanguageID.abbreviation: "IN"]
+            ),
+            ID.delhiIndia: makeGeoname(
+                id: ID.delhiIndia,
+                name: "Delhi",
+                featureCode: "PPLC",
+                countryCode: "IN",
+                countryID: ID.india,
+                admin1ID: ID.delhiAdministrativeArea,
+                ranking: 0.9
+            ),
+            ID.delhiAdministrativeArea: makeGeoname(
+                id: ID.delhiAdministrativeArea,
+                name: "National Capital Territory of Delhi",
+                featureCode: "ADM1",
+                countryCode: "IN",
+                countryID: ID.india,
+                admin1ID: ID.delhiAdministrativeArea,
+                alternativeNames: [LanguageID.abbreviation: "DL"]
+            ),
+            ID.delhiIndiana: makeGeoname(
+                id: ID.delhiIndiana,
+                name: "Delhi",
+                featureCode: "PPL",
+                countryCode: "US",
+                countryID: ID.unitedStates,
+                admin1ID: ID.indiana,
+                ranking: 0.4
+            ),
+            ID.sharedIndia: makeGeoname(
+                id: ID.sharedIndia,
+                name: "Shared Region",
+                featureCode: "ADM1",
+                countryCode: "IN",
+                countryID: ID.india,
+                admin1ID: ID.sharedIndia,
+                alternativeNames: [
+                    LanguageID.english: "Shared Region",
+                    LanguageID.german: "Gemeinsam",
+                ]
+            ),
+            ID.sharedUnitedStates: makeGeoname(
+                id: ID.sharedUnitedStates,
+                name: "Shared Region",
+                featureCode: "ADM1",
+                countryCode: "US",
+                countryID: ID.unitedStates,
+                admin1ID: ID.sharedUnitedStates,
+                alternativeNames: [LanguageID.german: "Gemeinsam"]
+            ),
+            ID.puertoRico: makeGeoname(
+                id: ID.puertoRico,
+                name: "Puerto Rico",
+                featureCode: "PCLD",
+                countryCode: "PR",
+                countryID: 0
+            ),
+            ID.sanJuanMunicipality: makeGeoname(
+                id: ID.sanJuanMunicipality,
+                name: "San Juan",
+                featureCode: "ADM1",
+                countryCode: "PR",
+                countryID: 0,
+                admin1ID: ID.sanJuanMunicipality
+            ),
+            ID.sanJuan: makeGeoname(
+                id: ID.sanJuan,
+                name: "San Juan",
+                featureCode: "PPLA",
+                countryCode: "PR",
+                countryID: 0,
+                admin1ID: ID.sanJuanMunicipality,
+                ranking: 0.8
+            ),
+            ID.guam: makeGeoname(
+                id: ID.guam,
+                name: "Guam",
+                featureCode: "PCLD",
+                countryCode: "GU",
+                countryID: 0
+            ),
+            ID.dededoMunicipality: makeGeoname(
+                id: ID.dededoMunicipality,
+                name: "Dededo Municipality",
+                featureCode: "ADM1",
+                countryCode: "GU",
+                countryID: 0,
+                admin1ID: ID.dededoMunicipality
+            ),
+            ID.dededoVillage: makeGeoname(
+                id: ID.dededoVillage,
+                name: "Dededo Village",
+                featureCode: "PPL",
+                countryCode: "GU",
+                countryID: 0,
+                admin1ID: ID.dededoMunicipality,
+                ranking: 0.7
+            ),
+            ID.hongKong: makeGeoname(
+                id: ID.hongKong,
+                name: "Hong Kong",
+                featureCode: "PCLS",
+                countryCode: "HK",
+                countryID: 0,
+                ranking: 0.9
+            ),
+        ]
+        return geonames
+    }
+
+    private func makeGeoname(
+        id: Int32,
+        name: String,
+        featureCode: String,
+        countryCode: String,
+        countryID: Int32,
+        admin1ID: Int32 = 0,
+        ranking: Float = 0,
+        alternativeNames: [Int32: String] = [:]
+    ) -> GeocodingDatabase.Geoname {
+        var geoname = GeocodingDatabase.Geoname()
+        geoname.id = id
+        geoname.name = name
+        geoname.latitude = Float(id)
+        geoname.longitude = Float(id)
+        geoname.ranking = ranking
+        geoname.featureCode = featureCode
+        geoname.countryIso2 = countryCode
+        geoname.countryID = countryID
+        geoname.admin1ID = admin1ID
+        geoname.alternativeNames = alternativeNames
+        return geoname
+    }
+}


### PR DESCRIPTION
Closes https://github.com/open-meteo/geocoding-api/issues/33 and https://github.com/open-meteo/geocoding-api/issues/26.

  - Adds a dedicated exact-match `Sources/App/AdministrativeAreaLookup.swift` for:
      - ADM1 names and abbreviations.
      - Country names and ISO codes.
      - Localized, English, and language-neutral aliases.
      - Country-like GeoNames types including dependent territories.
  - Updates `Sources/App/GeocodingapiController.swift` to:
      - Parse place, qualifier searches.
      - Stop the qualifier at the next comma.
      - Combine qualifier resolution with an explicit countryCode.
      - Pass filtering into the database search instead of filtering final results.
  - Extends `Sources/App/GeocodingDatabase.swift` with optional country and administrative-area constraints.
  - Adds candidate acceptance to `Sources/App/Structures.swift`, applying filters before result truncation.

Performance overhead should be modest and concentrated during initialization: one digit seconds overhead during loading the database (2.4s on my machine) and about 30 MB extra RSS usage.   